### PR TITLE
Resolving issue by returning Promise<[U]> instead Guarantee<[U]>

### DIFF
--- a/CancellablePromiseKit/Classes/when.swift
+++ b/CancellablePromiseKit/Classes/when.swift
@@ -53,8 +53,14 @@ public func when<T>(fulfilled cancellablePromises: [CancellablePromise<T>]) -> C
  */
 public func when<T>(resolved cancellablePromises: [CancellablePromise<T>], autoCancel: Bool) -> CancellablePromise<[Result<T>]> {
     return CancellablePromise { (cancelPromise) -> Promise<[Result<T>]> in
-        let guarantee = when(resolved: cancellablePromises.map{ $0.asPromise() })
-        let promise = guarantee.mapValues({ v in return v })
+        let guarantee = when(resolved: cancellablePromises.map { $0.asPromise() })
+        let promise = guarantee.mapValues { (value: Result<T>) -> Result<T> in
+            if false {
+                throw PMKError.cancelled
+            }
+            return value
+        }
+        
         return when(promise, while: cancelPromise).ensure {
             if autoCancel {
                 cancelAll(in: cancellablePromises)


### PR DESCRIPTION
PromiseKit: 6.10.0 (or older version)

fix parameter matching confusion, which cause by:

on protocol Guarantee:
func mapValues<U>(on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, _ transform: @escaping(T.Iterator.Element) -> U) -> Guarantee<[U]>

on protocol Thenable:
func mapValues<U>(on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, _ transform: @escaping(T.Iterator.Element) throws -> U) -> Promise<[U]>